### PR TITLE
use url of the context

### DIFF
--- a/plone/batching/browser.py
+++ b/plone/batching/browser.py
@@ -38,5 +38,5 @@ class PloneBatchView(BatchView):
             batchlinkparams = form.copy()
 
         start = max(pagenumber - 1, 0) * self.batch.pagesize
-        return '%s?%s' % (self.request.ACTUAL_URL, make_query(batchlinkparams,
+        return '%s?%s' % (self.context.absolute_url(), make_query(batchlinkparams,
                          {self.batch.b_start_str: start}))


### PR DESCRIPTION
Better to use the url of the context where the pagination should appear on, not the url you are on (when you use a folder to show 2 collections with all contents view, the batching showed a link to the folder, not to the pages inside the collection, this fixes that)